### PR TITLE
instrumentation: pass on UUID to wrapped promises

### DIFF
--- a/instrumented/instrumentation.go
+++ b/instrumented/instrumentation.go
@@ -164,6 +164,12 @@ func (i *Instrumentation) Reject(err error) Promise {
 // instrumentation. If the provided promise is already instrumented, the newly
 // wrapped promise will adpot the UUID of the delegate.
 func (i *Instrumentation) Wrap(delegate Promise) Promise {
+	return i.wrap(delegate, func() string {
+		return uuid.New().String()
+	})
+}
+
+func (i *Instrumentation) wrap(delegate Promise, newUUID func() string) Promise {
 	if len(i.Handlers()) == 0 {
 		// If the instrumentation has no handlers there is no point in wrapping
 		// the delegate promise as this would just introduce unnecessary
@@ -196,7 +202,7 @@ func (i *Instrumentation) Wrap(delegate Promise) Promise {
 	// Wrap it and assign a new UUID.
 	return &instrumentedPromise{
 		delegate:        delegate,
-		uuid:            uuid.New().String(),
+		uuid:            newUUID(),
 		instrumentation: i,
 	}
 }

--- a/instrumented/instrumentation_test.go
+++ b/instrumented/instrumentation_test.go
@@ -151,6 +151,9 @@ func TestInstrumentedPromise_WrapDelegate(t *testing.T) {
 }
 
 func TestInstrumentedPromise_WrapOther(t *testing.T) {
+	AddInstrumentationHandlers(noopHandler)
+	defer RemoveInstrumentationHandlers()
+
 	p := promise.Resolve(42)
 	q := promise.Resolve(23)
 
@@ -159,7 +162,12 @@ func TestInstrumentedPromise_WrapOther(t *testing.T) {
 		delegate:        p,
 	}
 
-	if instrumented.wrap(q) == instrumented {
+	wrapped := instrumented.wrap(q)
+	if wrapped == instrumented {
 		t.Fatalf("expected promises to be the different")
+	}
+
+	if wrapped.(*instrumentedPromise).uuid != instrumented.uuid {
+		t.Fatalf("expected uuids to be the same")
 	}
 }

--- a/instrumented/promise.go
+++ b/instrumented/promise.go
@@ -32,7 +32,10 @@ func (p *instrumentedPromise) wrap(candidate Promise) Promise {
 		return p
 	}
 
-	return p.instrumentation.Wrap(candidate)
+	// Wrap it and set the UUID of p on the wrapped promise.
+	return p.instrumentation.wrap(candidate, func() string {
+		return p.uuid
+	})
 }
 
 func (p *instrumentedPromise) onRejectedFunc(onRejected OnRejectedFunc) OnRejectedFunc {


### PR DESCRIPTION
Depending on whether a promise is already resolved (fulfilled/rejected)
or still pending, calls to Then, Catch and Finally behave differently.
For pending promises this will return the promise itself, whereas for
fulfilled or rejected promises the calls will return new promises.

This also means that right now we generate new UUIDs for fullfilled and
rejected promises although the call chain originated from the same
source.

To fix that, we pass on the UUID when wrapping promises in Then, Catch
and Finally handlers to make it possible to trace the whole lifetime of
a call chain until either Await is called or the promise goes out of
scope (i.e. fulfills/rejects and no further handlers are attached to
it).