### PR TITLE
add coverage for cancellation while waiting for sem

### DIFF
--- a/extensions.go
+++ b/extensions.go
@@ -103,7 +103,9 @@ func (e AggregateError) Error() string {
 
 	return fmt.Sprintf(
 		"%d promises rejected due to errors:\n%s",
-		len(e), strings.Join(errStrings, "\n"))
+		len(e),
+		strings.Join(errStrings, "\n"),
+	)
 }
 
 // Any takes a slice of promises and, as soon as one of the promises in the

--- a/promise.go
+++ b/promise.go
@@ -122,7 +122,7 @@ type handler struct {
 // `reject` will cause the promise to stay in a pending state.
 func New(fn ResolutionFunc) Promise {
 	if fn == nil {
-		panic("resolution func must be non-nil")
+		panic("promise.New: resolution func must be non-nil")
 	}
 
 	p := &promise{


### PR DESCRIPTION
This also updates the pooled DNS lookup example to continue on errors to
also demonstrate pool options in the example. Also the panic messages
are improved.